### PR TITLE
Add 'OrganizationAccountAccessRole' to roles enumeration wordlist

### DIFF
--- a/tools/aws-pentest-tools/assume_role_enum/default-word-list.txt
+++ b/tools/aws-pentest-tools/assume_role_enum/default-word-list.txt
@@ -384,6 +384,7 @@ Onie
 OpsClarity-Access
 OpsWorks
 Orbitera
+OrganizationAccountAccessRole
 Orville
 P
 Palmer


### PR DESCRIPTION
This role is provisioned automatically by AWS when an account is joined to an AWS organization, so it can be a quickwin in a lot of situations. c.f. https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_access.html

> If you create an account by using the tools provided as part of AWS Organizations, you can access the account by using the preconfigured role named OrganizationAccountAccessRole that exists in all new accounts that are created this way.